### PR TITLE
fixing language input for Docker prompt

### DIFF
--- a/src/commands/cloneProjectLocally.ts
+++ b/src/commands/cloneProjectLocally.ts
@@ -15,8 +15,7 @@ export async function cloneLocally(context: IActionContext, node?: SlotTreeItemB
 
     const filePathUri: vscode.Uri[] = await ext.ui.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false });
     const resourceId: string = node.id;
-    const language: string = "python";
-    //const language: string = node.getApplicationLanguage().get;
+    const language: string = await node.getApplicationLanguage();
 
     await setupProjectFolderParsed(resourceId, language, filePathUri[0], context, node);
 }

--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -138,11 +138,10 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
     // get language of the Function App from the Settings
     public async getApplicationLanguage(): Promise<string> {
         const appSettings: WebSiteManagementModels.StringDictionary = await this.root.client.listApplicationSettings();
-        if (appSettings.properties == undefined) {
-            appSettings.properties = {};
-        }
-        const appRuntime: string = appSettings.properties.FUNCTIONS_WORKER_RUNTIME;
-        return appRuntime;
+
+        return !appSettings.properties || !appSettings.properties['FUNCTIONS_WORKER_RUNTIME']
+            ? ''
+            : appSettings.properties['FUNCTIONS_WORKER_RUNTIME'];
     }
 
     public async setApplicationSetting(_context: IActionContext, key: string, value: string): Promise<void> {


### PR DESCRIPTION
Language input is no longer returning an empty object when being called from the `CloneProjectLocally.ts` file.

Added an async function to `SlotTreeItemBase` type to get the Function App runtime language from its Settings. 