### PR TITLE
Added Functionality to download Docker files Directly

### DIFF
--- a/src/commands/downloadDevContainer.ts
+++ b/src/commands/downloadDevContainer.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { WorkspaceFolder } from "vscode";
 import { IActionContext } from "vscode-azureextensionui";
 import { getDevContainerName } from '../downloadAzureProject/setupProjectFolder';
@@ -29,6 +30,18 @@ export async function downloadDevContainer(context: IActionContext, node: SlotTr
         path.join(devContainerFolderPath, 'Dockerfile')
 
     );
+
+    const reloadVSCode: string = localize('reload', 'Reload Current Folder');
+    const newWindow: string = localize('reload', 'Open New Folder');
+    void vscode.window.showInformationMessage(localize('downloaded', 'Successfully downloaded dev container files'), reloadVSCode, newWindow).then(async result => {
+        if (result === reloadVSCode) {
+            await vscode.commands.executeCommand('workbench.action.reloadWindow');
+        } else if (result === newWindow) {
+            const projectFilePath: string = devContainerFolderPath.substring(0, devContainerFolderPath.length - 13);
+            await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectFilePath), true); // open the project in VS Code
+
+        }
+    });
 }
 
 export async function getDevContainerFolder(context: IActionContext, message: string, workspacePath?: string): Promise<string> {

--- a/src/commands/downloadDevContainer.ts
+++ b/src/commands/downloadDevContainer.ts
@@ -3,45 +3,54 @@ import * as vscode from 'vscode';
 import { WorkspaceFolder } from "vscode";
 import { IActionContext } from "vscode-azureextensionui";
 import { getDevContainerName } from '../downloadAzureProject/setupProjectFolder';
+import { ext } from '../extensionVariables';
 import { localize } from "../localize";
+import { ProductionSlotTreeItem } from '../tree/ProductionSlotTreeItem';
 import { SlotTreeItemBase } from '../tree/SlotTreeItemBase';
 import { requestUtils } from '../utils/requestUtils';
 import { selectWorkspaceFolder } from '../utils/workspace';
 import { tryGetFunctionProjectRoot } from './createNewProject/verifyIsProject';
 
 
-export async function downloadDevContainer(context: IActionContext, node: SlotTreeItemBase): Promise<void> {
+export async function downloadDevContainer(context: IActionContext, node?: SlotTreeItemBase): Promise<void> {
+    if (!node) {
+        node = await ext.tree.showTreeItemPicker<SlotTreeItemBase>(ProductionSlotTreeItem.contextValue, context);
+    }
 
     const language: string = await node.getApplicationLanguage();
     const devContainerName = getDevContainerName(language);
-    const message: string = localize('selectDevContainer', 'Select the destination file for the dev container folder.');
-    let devContainerFolderPath: string = await getDevContainerFolder(context, message);
+    if (devContainerName && node.site.reserved) {
+        const message: string = localize('selectDevContainer', 'Select the destination file for the dev container folder.');
+        let devContainerFolderPath: string = await getDevContainerFolder(context, message);
 
-    if (devContainerFolderPath.substring(devContainerFolderPath.length - 13) != '.devcontainer') {
-        devContainerFolderPath = path.join(devContainerFolderPath, '.devcontainer');
-    }
-    await requestUtils.downloadFile(
-        `https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/${devContainerName}/.devcontainer/devcontainer.json`,
-        path.join(devContainerFolderPath, 'devcontainer.json')
-
-    );
-    await requestUtils.downloadFile(
-        `https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/${devContainerName}/.devcontainer/Dockerfile`,
-        path.join(devContainerFolderPath, 'Dockerfile')
-
-    );
-
-    const reloadVSCode: string = localize('reload', 'Reload Current Folder');
-    const newWindow: string = localize('reload', 'Open New Folder');
-    void vscode.window.showInformationMessage(localize('downloaded', 'Successfully downloaded dev container files'), reloadVSCode, newWindow).then(async result => {
-        if (result === reloadVSCode) {
-            await vscode.commands.executeCommand('workbench.action.reloadWindow');
-        } else if (result === newWindow) {
-            const projectFilePath: string = devContainerFolderPath.substring(0, devContainerFolderPath.length - 13);
-            await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectFilePath), true); // open the project in VS Code
-
+        if (devContainerFolderPath.substring(devContainerFolderPath.length - 13) != '.devcontainer') {
+            devContainerFolderPath = path.join(devContainerFolderPath, '.devcontainer');
         }
-    });
+        await requestUtils.downloadFile(
+            `https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/${devContainerName}/.devcontainer/devcontainer.json`,
+            path.join(devContainerFolderPath, 'devcontainer.json')
+
+        );
+        await requestUtils.downloadFile(
+            `https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/${devContainerName}/.devcontainer/Dockerfile`,
+            path.join(devContainerFolderPath, 'Dockerfile')
+
+        );
+
+        const reloadVSCode: string = localize('reload', 'Reload Current Folder');
+        const newWindow: string = localize('reload', 'Open New Folder');
+        void vscode.window.showInformationMessage(localize('downloaded', 'Successfully downloaded dev container files'), reloadVSCode, newWindow).then(async result => {
+            if (result === reloadVSCode) {
+                await vscode.commands.executeCommand('workbench.action.reloadWindow');
+            } else if (result === newWindow) {
+                const projectFilePath: string = devContainerFolderPath.substring(0, devContainerFolderPath.length - 13);
+                await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectFilePath), true); // open the project in VS Code
+
+            }
+        });
+    } else {
+        void vscode.window.showInformationMessage(localize('noDownload', 'Conditions not met. Cant use Docker with this project'));
+    }
 }
 
 export async function getDevContainerFolder(context: IActionContext, message: string, workspacePath?: string): Promise<string> {
@@ -52,4 +61,3 @@ export async function getDevContainerFolder(context: IActionContext, message: st
         return path.relative(workspacePath, projectPath);
     });
 }
-

--- a/src/downloadAzureProject/setupProjectFolder.ts
+++ b/src/downloadAzureProject/setupProjectFolder.ts
@@ -112,7 +112,7 @@ function getProjectLanguageForLanguage(language: string): ProjectLanguage {
 
 // gets the devContainer name based on the language
 // here we define which functions will have docker support
-function getDevContainerName(language: string): string | undefined {
+export function getDevContainerName(language: string): string | undefined {
     switch (language) {
         case 'node':
             return 'azure-functions-node';


### PR DESCRIPTION
Created downloadDevContainer.ts that will download just the two dev container files for a certain project. We will ask the user where they want to download it to. If they have a folder open in VS Code, they will see this prompt with the suggested location being their open project and the browse option if they want to download it elsewhere
<img width="312" alt="browsepromt" src="https://user-images.githubusercontent.com/55974511/125849990-e65faa11-d5f8-4e07-b8e2-9a636e298069.PNG">
If they don't have any projects open, file explorer will open and they can choose any folder for the file location.
Then at the end of the download they will get this message with the option to either reload their current project or open a project in a new window so that VS Code will detect the dev container files and the option to Reopen in Container will appear.
<img width="298" alt="successimage" src="https://user-images.githubusercontent.com/55974511/125849992-4a2706bf-bece-4fcd-9b0c-d8a5a4a14cf7.PNG">
