### PR TITLE
Updating Pop Up Messages

### DIFF
--- a/src/commands/dockersupport/askDockerStep.ts
+++ b/src/commands/dockersupport/askDockerStep.ts
@@ -19,18 +19,3 @@ export async function prompt(context: IActionContext): Promise<string> {
     const dockersupport: string = (await context.ui.showQuickPick(responses, question)).data;
     return dockersupport;
 }
-
-export async function prompt2(context: IActionContext): Promise<string> {
-    const question: QuickPickOptions = { placeHolder: localize('useDocker', 'We noticed you don\'t have Docker. Want to install it?') };
-    const responses: IAzureQuickPickItem<string>[] = [
-        // can customize the label name if needed
-        { label: 'Yes, install Docker', data: "yes" },
-        { label: 'No, do not install Docker', data: "no" }
-    ];
-
-    // pop up UI of the prompt and options at the top
-    const dockersupport: string = (await context.ui.showQuickPick(responses, question)).data;
-    return dockersupport;
-}
-
-

--- a/src/commands/dockersupport/localDockerSupport.ts
+++ b/src/commands/dockersupport/localDockerSupport.ts
@@ -8,7 +8,6 @@ import { prompt } from "./askDockerStep";
 import { validateDockerInstalled } from './validateDockerInstalled';
 
 export const DOCKER_PROMPT_YES = "yes";
-export const PLATFORM_WIN32 = "win32";
 
 /**
  * Main Function Called to initialize the Docker flow with cloning Function App project locally from VS Code Extension
@@ -22,22 +21,12 @@ export async function localDockerPrompt(context: IActionContext, devContainerFol
         if (await prompt(context) === DOCKER_PROMPT_YES) {
             await downloadLocalDevFiles(devContainerFolderPathUri, devContainerName);
             if (!validateDockerInstalled()) {
-                if (process.platform.toLowerCase() === PLATFORM_WIN32) {
-                    // Download Docker with an MSI package
-                    const dockerMSI: string = localize('msi', 'Download Docker');
-                    await vscode.window.showInformationMessage(localize('download', 'We noticed you don\'t have Docker installed. Download for the best user experience.'), dockerMSI,).then(async result => {
-                        if (result === dockerMSI) {
-                            await openUrl('https://docs.docker.com/get-docker/');
-                        }
-                    });
-                } else {
-                    const dockerDocumentation: string = localize('documentation', 'Docker Documentation');
-                    await vscode.window.showInformationMessage(localize('download', 'We noticed you don\'t have Docker installed. Check the Docker Documentation to download Docker to your system.'), dockerDocumentation,).then(async result => {
-                        if (result === dockerDocumentation) {
-                            await openUrl('https://docs.docker.com/get-docker/');
-                        }
-                    });
-                }
+                const dockerDocumentation: string = localize('documentation', 'Docker Documentation');
+                await vscode.window.showInformationMessage(localize('download', 'We noticed you don\'t have Docker installed. Check the Docker Documentation to download Docker to your system.'), dockerDocumentation,).then(async result => {
+                    if (result === dockerDocumentation) {
+                        await openUrl('https://docs.docker.com/get-docker/');
+                    }
+                });
             }
         } else {
             void vscode.window.showInformationMessage(localize('noDocker', 'Continuing without the use of Docker as user requested'));

--- a/src/commands/dockersupport/localDockerSupport.ts
+++ b/src/commands/dockersupport/localDockerSupport.ts
@@ -2,9 +2,10 @@ import * as vscode from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
 import { localize } from '../../localize';
 import { SlotTreeItemBase } from "../../tree/SlotTreeItemBase";
+import { openUrl } from '../../utils/openUrl';
 import { requestUtils } from "../../utils/requestUtils";
-import { prompt, prompt2 } from "./askDockerStep";
-import { validateDockerInstalled } from "./validateDockerInstalled";
+import { prompt } from "./askDockerStep";
+import { validateDockerInstalled } from './validateDockerInstalled';
 
 export const DOCKER_PROMPT_YES = "yes";
 export const PLATFORM_WIN32 = "win32";
@@ -18,22 +19,24 @@ export const PLATFORM_WIN32 = "win32";
  */
 export async function localDockerPrompt(context: IActionContext, devContainerFolderPathUri: vscode.Uri, node?: SlotTreeItemBase, devContainerName?: string): Promise<void> {
     if (node && devContainerName && node.site.reserved) {
-        // asks if the user wants to use Docker for initializing the project locally
         if (await prompt(context) === DOCKER_PROMPT_YES) {
             await downloadLocalDevFiles(devContainerFolderPathUri, devContainerName);
-            // external - check if Docker is installed, Remote Development extension AND Docker Extension
             if (!validateDockerInstalled()) {
-                // if Docker is not downloaded - ask the user if they'd like to download Docker
-                if (await prompt2(context) === DOCKER_PROMPT_YES) {
-                    // Check if Operating System is Windows
-                    if (process.platform.toLowerCase() === PLATFORM_WIN32) {
-                        // Download Docker with an MSI package
-                    } else {
-                        // Not windows: display link to download docker externally from Docker documentation
-                        void vscode.window.showInformationMessage(localize('downloadDocker', 'Check the (Docker documentation)[https://docs.docker.com/get-docker/] to download Docker for your system'));
-                    }
+                if (process.platform.toLowerCase() === PLATFORM_WIN32) {
+                    // Download Docker with an MSI package
+                    const dockerMSI: string = localize('msi', 'Download Docker');
+                    await vscode.window.showInformationMessage(localize('download', 'We noticed you don\'t have Docker installed. Download for the best user experience.'), dockerMSI,).then(async result => {
+                        if (result === dockerMSI) {
+                            await openUrl('https://docs.docker.com/get-docker/');
+                        }
+                    });
                 } else {
-                    void vscode.window.showInformationMessage(localize('noDocker', 'Continuing without the use of Docker as user requested'));
+                    const dockerDocumentation: string = localize('documentation', 'Docker Documentation');
+                    await vscode.window.showInformationMessage(localize('download', 'We noticed you don\'t have Docker installed. Check the Docker Documentation to download Docker to your system.'), dockerDocumentation,).then(async result => {
+                        if (result === dockerDocumentation) {
+                            await openUrl('https://docs.docker.com/get-docker/');
+                        }
+                    });
                 }
             }
         } else {

--- a/src/downloadAzureProject/setupProjectFolder.ts
+++ b/src/downloadAzureProject/setupProjectFolder.ts
@@ -70,7 +70,8 @@ export async function setupProjectFolderParsed(resourceId: string, language: str
             await initProjectForVSCode(context, projectFilePath, getProjectLanguageForLanguage(language));
 
             void vscode.window.showInformationMessage(localize('restartingVsCodeInfoMessage', 'Restarting VS Code with your function app project'));
-            await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectFilePath), true);
+            const delayMilliseconds = 1500;
+            setTimeout(vscode.commands.executeCommand, delayMilliseconds, 'vscode.openFolder', vscode.Uri.file(projectFilePath), true)
         });
     } catch (err) {
         throw new Error(localize('failedLocalProjSetupErrorMessage', 'Failed to set up your local project: "{0}".', parseError(err).message));


### PR DESCRIPTION
Updating the messages for downloading docker when user does not have it for better user experience.

This message shows up when user is windows and soon we will be able to link the MSI Download here. For now it only takes you to the docker documentation as a placeholder.
<img width="300" alt="PR8downloadDockerWindows" src="https://user-images.githubusercontent.com/55974511/126381457-ae59708b-bf7a-4c2e-a5cc-539723cd1c43.PNG">
This is the message that shows up for non-Windows users and it takes you to the docker documentation to download docker from there.
<img width="298" alt="PR8downloadDockerNonWindows" src="https://user-images.githubusercontent.com/55974511/126381471-840b0b17-8c2f-4b61-bbef-7980393ad014.PNG">

Also, I added a delay so that users are able to see the Restarting VSCode messege  before a new VSCode window appears in front of it.
<img width="296" alt="PR8restartingVSCode" src="https://user-images.githubusercontent.com/55974511/126381961-73786db1-1652-4bf2-af32-7b3b25cedb3e.PNG">
