### PR TITLE
Implementation of Multi-Select UI for Upload App Settings

### DIFF
--- a/src/commands/appSettings/downloadAppSettings.ts
+++ b/src/commands/appSettings/downloadAppSettings.ts
@@ -46,14 +46,14 @@ export async function downloadAppSettingsInternal(context: IActionContext, clien
         if (!localSettings.Values) {
             localSettings.Values = {};
         }
-        if (!localSettings.SettingsToIgnore) {
-            localSettings.SettingsToIgnore = [];
+        if (!localSettings.SettingsToIgnoreOnDeployment) {
+            localSettings.SettingsToIgnoreOnDeployment = [];
         }
         const remoteSettings: WebSiteManagementModels.StringDictionary = await client.listApplicationSettings();
 
         ext.outputChannel.appendLog(localize('downloadingSettings', 'Downloading settings...'), { resourceName: client.fullName });
         if (remoteSettings.properties) {
-            await filterDownloadAppSettings(context, remoteSettings.properties, localSettings.Values, localSettings.SettingsToIgnore, localSettingsFileName);
+            await filterDownloadAppSettings(context, remoteSettings.properties, localSettings.Values, localSettings.SettingsToIgnoreOnDeployment, localSettingsFileName);
         }
 
         await fse.ensureFile(localSettingsPath);

--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -49,13 +49,13 @@ export async function uploadAppSettingsInternal(context: IActionContext, client:
         if (!remoteSettings.properties) {
             remoteSettings.properties = {};
         }
-        if (!localSettings.SettingsToIgnore) {
-            localSettings.SettingsToIgnore = [];
+        if (!localSettings.SettingsToIgnoreOnDeployment) {
+            localSettings.SettingsToIgnoreOnDeployment = [];
         }
 
         const uploadSettings: string = localize('uploadingSettings', 'Uploading settings...');
         ext.outputChannel.appendLog(uploadSettings, { resourceName: client.fullName });
-        await filterUploadAppSettings(localSettings.Values, remoteSettings.properties, localSettings.SettingsToIgnore, client.fullName);
+        await filterUploadAppSettings(context, localSettings.Values, remoteSettings.properties, localSettings.SettingsToIgnoreOnDeployment, client.fullName);
 
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('uploadingSettingsTo', 'Uploading settings to "{0}"...', client.fullName) }, async () => {
             await client.updateApplicationSettings(remoteSettings);

--- a/src/funcConfig/local.settings.ts
+++ b/src/funcConfig/local.settings.ts
@@ -15,7 +15,7 @@ import { parseJson } from '../utils/parseJson';
 export interface ILocalSettingsJson {
     IsEncrypted?: boolean;
     Values?: { [key: string]: string };
-    SettingsToIgnore?: string[];
+    SettingsToIgnoreOnDeployment?: string[];
     Host?: { [key: string]: string };
     ConnectionStrings?: { [key: string]: string };
 }


### PR DESCRIPTION
This PR is for the implementation of a multi-select UI during the uploading app settings flow:
<img width="453" alt="SC of Upload UI" src="https://user-images.githubusercontent.com/70758549/127199426-2bf922db-372a-430c-82c1-5ebe05508def.PNG">

Another edit I made was renaming the SettingsToIgnore field in the local.settings.json file to SettingsToIgnoreOnDeployment which accounts for the changes in local.settings.ts, uploadAppSettings.ts and downloadAppSettings.ts.

In regards to the multi-select UI, an array "options" is initialized with a list of the user's app settings that were modified but are not included in the SettingsToIgnoreOnDeployment field.
<img width="616" alt="sc of options init" src="https://user-images.githubusercontent.com/70758549/127200055-a83b07bf-51bc-4c66-87d4-703f4bd4df47.PNG">

If there any modified app settings meeting the above requirements, then a multi-select UI is created prompting the user to select the modified app settings they would like to upload. If there were no modified app settings then the "userChosenSettings", which is the array that contains the app settings the user would like to upload, remains empty.
<img width="624" alt="sc of UI prompt" src="https://user-images.githubusercontent.com/70758549/127200274-e22f2b33-1244-47a3-b32d-26ec93bb67bb.PNG">

The filter logic below is then activated in order to upload any necessary settings and record the output which is later shown to the user.
<img width="560" alt="sc of filter logic" src="https://user-images.githubusercontent.com/70758549/127200715-8a5583ed-e055-47d7-ad76-c827c0ce073f.PNG">
 
