### PR TITLE
Adding "Reopen in Container" explorer menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
         "onCommand:azureFunctions.setAzureWebJobsStorage",
         "onCommand:azureFunctions.reportIssue",
         "onCommand:azureFunctions.cloneLocally",
+        "onCommand:azureFunctions.reopenInContainer",
+        "onCommand:azureFunctions.updateContainer",
         "workspaceContains:**/host.json",
         "onView:azFuncTree",
         "onDebugInitialConfigurations",
@@ -362,6 +364,16 @@
             {
                 "command": "azureFunctions.reportIssue",
                 "title": "%azureFunctions.reportIssue%",
+                "category": "Azure Functions"
+            },
+            {
+                "command": "azureFunctions.reopenInContainer",
+                "title": "%azureFunctions.reopenInContainer%",
+                "category": "Azure Functions"
+            },
+            {
+                "command": "azureFunctions.updateContainer",
+                "title": "%azureFunctions.updateContainer%",
                 "category": "Azure Functions"
             }
         ],
@@ -679,6 +691,16 @@
                     "command": "azureFunctions.deploy",
                     "when": "explorerResourceIsFolder == true",
                     "group": "zzz_azuretools_deploy@2"
+                },
+                {
+                    "command": "azureFunctions.reopenInContainer",
+                    "when": "explorerResourceIsFolder == true && resourceFilename != .devcontainer",
+                    "group": "zzz_azuretools_deploy@3"
+                },
+                {
+                    "command": "azureFunctions.updateContainer",
+                    "when": "explorerResourceIsFolder == true && resourceFilename == .devcontainer",
+                    "group": "zzz_azuretools_deploy@4"
                 },
                 {
                     "command": "azureFunctions.appSettings.decrypt",

--- a/package.nls.json
+++ b/package.nls.json
@@ -100,7 +100,7 @@
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",
     "azureFunctions.viewProperties": "View Properties",
-    "azureFunctions.cloneLocally": "Clone Project Locally...",
+    "azureFunctions.cloneLocally": "Download Project...",
     "azureFunctions.reopenInContainer": "Reopen in Container...",
     "azureFunctions.updateContainer": "Update Dev Container..."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -100,5 +100,7 @@
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",
     "azureFunctions.viewProperties": "View Properties",
-    "azureFunctions.cloneLocally": "Clone Project Locally..."
+    "azureFunctions.cloneLocally": "Clone Project Locally...",
+    "azureFunctions.reopenInContainer": "Reopen in Container...",
+    "azureFunctions.updateContainer": "Update Dev Container..."
 }

--- a/src/commands/dockersupport/getProjectFolder.ts
+++ b/src/commands/dockersupport/getProjectFolder.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import { WorkspaceFolder } from "vscode";
+import { IActionContext } from "vscode-azureextensionui";
+import { selectWorkspaceFolder } from '../../utils/workspace';
+import { tryGetFunctionProjectRoot } from '../createNewProject/verifyIsProject';
+
+/**
+ * Returns the path of an opened function app project
+ */
+export async function getProjectFolder(context: IActionContext, message: string, workspacePath?: string): Promise<string> {
+
+    return await selectWorkspaceFolder(context, message, async (f: WorkspaceFolder): Promise<string> => {
+        workspacePath = f.uri.fsPath;
+        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath) || workspacePath;
+        return path.relative(workspacePath, projectPath);
+    });
+}

--- a/src/commands/dockersupport/reopenInContainer.ts
+++ b/src/commands/dockersupport/reopenInContainer.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { AzExtTreeItem } from 'vscode-azureextensionui';
+import { localize } from '../../localize';
+import { IProjectWizardContext } from '../createNewProject/IProjectWizardContext';
+import { getProjectFolder } from './getProjectFolder';
+
+/**
+ * Explorer menu item which reopens the local app functions project in a dev container
+ */
+export async function reopenInContainer(context: IProjectWizardContext, node?: AzExtTreeItem): Promise<void> {
+
+    try {
+        if (node) {
+            const message: string = localize('selectFunctionProject', 'Select your App Functions Project');
+            const projectFilePath: string = await getProjectFolder(context, message, context.workspacePath);
+            vscode.commands.executeCommand('remote-containers.reopenInContainer', vscode.Uri.file(projectFilePath));
+        } else {
+            void vscode.window.showInformationMessage(localize('noProjectOpened', 'Conditions not met. Cannot use Docker with this project'));
+        }
+    } catch (error) {
+        void vscode.window.showInformationMessage(localize('failReopenInContainer', 'Failed to reopen project in a dev container.'));
+    }
+}

--- a/src/commands/dockersupport/reopenInContainer.ts
+++ b/src/commands/dockersupport/reopenInContainer.ts
@@ -18,7 +18,7 @@ export async function reopenInContainer(context: IProjectWizardContext, node?: A
         if (node) {
             const message: string = localize('selectFunctionProject', 'Select your App Functions Project');
             const projectFilePath: string = await getProjectFolder(context, message, context.workspacePath);
-            vscode.commands.executeCommand('remote-containers.reopenInContainer', vscode.Uri.file(projectFilePath));
+            void vscode.commands.executeCommand('remote-containers.reopenInContainer', vscode.Uri.file(projectFilePath));
         } else {
             void vscode.window.showInformationMessage(localize('noProjectOpened', 'Conditions not met. Cannot use Docker with this project'));
         }

--- a/src/commands/dockersupport/updateContainer.ts
+++ b/src/commands/dockersupport/updateContainer.ts
@@ -15,7 +15,7 @@ export async function updateContainer(context: IActionContext, node: AzExtTreeIt
 
     try {
         const projectFilePath: string = await getProjectFolder(context, node.label);
-        vscode.commands.executeCommand('remote-containers.rebuildAndReopenInContainer', vscode.Uri.file(projectFilePath))
+        void vscode.commands.executeCommand('remote-containers.rebuildAndReopenInContainer', vscode.Uri.file(projectFilePath))
     } catch (error) {
         void vscode.window.showInformationMessage(localize('cannotRebuildandReopen', 'Failed to update and reopen project in a dev container.'));
     }

--- a/src/commands/dockersupport/updateContainer.ts
+++ b/src/commands/dockersupport/updateContainer.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { AzExtTreeItem, IActionContext } from 'vscode-azureextensionui';
+import { localize } from '../../localize';
+import { getProjectFolder } from './getProjectFolder';
+
+/**
+ * Rebuilds and reopens the opened function app project in a dev container
+*/
+export async function updateContainer(context: IActionContext, node: AzExtTreeItem): Promise<void> {
+
+    try {
+        const projectFilePath: string = await getProjectFolder(context, node.label);
+        vscode.commands.executeCommand('remote-containers.rebuildAndReopenInContainer', vscode.Uri.file(projectFilePath))
+    } catch (error) {
+        void vscode.window.showInformationMessage(localize('cannotRebuildandReopen', 'Failed to update and reopen project in a dev container.'));
+    }
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -36,6 +36,8 @@ import { disconnectRepo } from './deployments/disconnectRepo';
 import { redeployDeployment } from './deployments/redeployDeployment';
 import { viewCommitInGitHub } from './deployments/viewCommitInGitHub';
 import { viewDeploymentLogs } from './deployments/viewDeploymentLogs';
+import { reopenInContainer } from './dockersupport/reopenInContainer';
+import { updateContainer } from './dockersupport/updateContainer';
 import { editAppSetting } from './editAppSetting';
 import { executeFunction } from './executeFunction';
 import { initProjectForVSCode } from './initProjectForVSCode/initProjectForVSCode';
@@ -109,4 +111,6 @@ export function registerCommands(): void {
     registerCommand('azureFunctions.viewProperties', viewProperties);
     registerCommand('azureFunctions.showOutputChannel', () => { ext.outputChannel.show(); });
     registerCommand('azureFunctions.cloneLocally', cloneLocally);
+    registerCommand('azureFunctions.reopenInContainer', reopenInContainer);
+    registerCommand('azureFunctions.updateContainer', updateContainer);
 }

--- a/src/downloadAzureProject/setupProjectFolder.ts
+++ b/src/downloadAzureProject/setupProjectFolder.ts
@@ -79,14 +79,15 @@ export async function setupProjectFolderParsed(resourceId: string, language: str
             const openInContainer: boolean = await localDockerPrompt(context, devContainerFolderPathUri, node, devContainerName);
             await initProjectForVSCode(context, projectFilePath, getProjectLanguageForLanguage(language));
 
-            void vscode.window.showInformationMessage(localize('restartingVsCodeInfoMessage', 'Restarting VS Code with your function app project'));
             // Setting a delay so that users are able to see the message before new window opens
             const delayMilliseconds = 1500;
             if (openInContainer) {
+                void vscode.window.showInformationMessage(localize('openInContainer', 'Restarting VS Code and opening function app project in container.'));
                 setTimeout((commandString, filePath, openFile) => {
                     void vscode.commands.executeCommand(commandString, filePath, openFile);
                 }, delayMilliseconds, 'remote-containers.openFolder', vscode.Uri.file(projectFilePath), true);
             } else {
+                void vscode.window.showInformationMessage(localize('restartingVsCodeInfoMessage', 'Restarting VS Code and opening function app project folder.'));
                 setTimeout((commandString, filePath, openFile) => {
                     void vscode.commands.executeCommand(commandString, filePath, openFile);
                 }, delayMilliseconds, 'vscode.openFolder', vscode.Uri.file(projectFilePath), true);


### PR DESCRIPTION
Added a new explorer menu item that reopens a local function app project in a dev container.
**"Reopen in Container..."** appears when the user right clicks a folder that is NOT the `.devcontainer` folder. Otherwise, **"Update Dev Container..."** appears when the user right clicks the `.devcontainer` folder, if it exists.

**"Reopen in Container..."** - Reopens the project in a dev container
<img width="335" alt="Screenshot 2021-08-02 115950" src="https://user-images.githubusercontent.com/61916412/127903812-f839c100-a02f-4446-abce-a8f0cc70a59b.png">

**"Update Dev Container..."** - Rebuilds the `.devcontainer` folder and reopens the project in the dev container
<img width="353" alt="Screenshot 2021-08-02 120040" src="https://user-images.githubusercontent.com/61916412/127903811-26fa5c33-57d5-4b51-aa26-71b565374707.png">